### PR TITLE
Fix missing command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-buf",
 	"displayName": "Buf",
 	"description": "Visual Studio Code support for Buf",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"icon": "logo.png",
 	"publisher": "bufbuild",
 	"repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { lint } from "./buf";
 import { isError } from "./errors";
 import { parseLines, Warning } from "./parser";
 
-export function activate(_: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
   const diagnosticCollection = vscode.languages.createDiagnosticCollection(
     "vscode-buf.lint"
   );
@@ -70,8 +70,17 @@ export function activate(_: vscode.ExtensionContext) {
     );
     diagnosticCollection.set(document.uri, diagnostics);
   };
-  vscode.workspace.onDidSaveTextDocument(doLint);
-  vscode.workspace.onDidOpenTextDocument(doLint);
+
+  context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(doLint));
+  context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(doLint));
+  context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      "vscode-buf.lint",
+      (textEditor: vscode.TextEditor) => {
+        doLint(textEditor.document);
+      }
+    )
+  );
 }
 
 // Nothing to do for now


### PR DESCRIPTION
The command was originally added, then removed in favor of onDidSaveTextDocumentand onDidOpenTextDocument callbacks, but we forgot to remove it from the package.json file. Readd the command so it can be invoked manually or via a keybinding.

Fixes #4