### PR TITLE
Add version checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Currently only supports linting but expect new features to be added soon!
 This extension contributes the following settings:
 
 - `buf.binaryPath`: configure the path to your buf binary. By default it uses `buf` in your `$PATH`.
+
+## Changelog
+
+- v0.1.0
+  - Add version check and download link
+- v0.0.3
+  - Fix missing generation command

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-buf",
 	"displayName": "Buf",
 	"description": "Visual Studio Code support for Buf",
-	"version": "0.0.3",
+	"version": "0.1.0",
 	"icon": "logo.png",
 	"publisher": "bufbuild",
 	"repository": {

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -2,11 +2,15 @@ import * as child_process from "child_process";
 import { Error } from "./errors";
 import { parse, Version } from "./version";
 
+// Don't defined latest version right now, adds a lot
+// of overhead to maintain.
+/*
 export const latestVersion = {
   major: 0,
   minor: 33,
   patch: 0,
 };
+*/
 
 export const minimumVersion = {
   major: 0,

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -1,5 +1,22 @@
 import * as child_process from "child_process";
 import { Error } from "./errors";
+import { parse, Version } from "./version";
+
+export const latestVersion = {
+  major: 0,
+  minor: 33,
+  patch: 0,
+};
+
+export const minimumVersion = {
+  major: 0,
+  // 0.31.0 was when we released --path
+  // https://groups.google.com/g/bufbuild-announce/c/5FRMd4Pm3Eo/m/p9579qKZAwAJ
+  minor: 31,
+  patch: 0,
+};
+
+export const downloadPage = "https://docs.buf.build/installation";
 
 export const lint = (
   binaryPath: string,
@@ -21,4 +38,14 @@ export const lint = (
     return [];
   }
   return output.stdout.trim().split("\n");
+};
+
+export const version = (binaryPath: string): Version | Error => {
+  const output = child_process.spawnSync(binaryPath, ["--version"], {
+    encoding: "utf-8",
+  });
+  if (output.error !== undefined) {
+    return { errorMessage: output.error.message };
+  }
+  return parse(output.stderr.trim());
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,5 @@
 import * as vscode from "vscode";
-import {
-  downloadPage,
-  latestVersion,
-  lint,
-  minimumVersion,
-  version,
-} from "./buf";
+import { downloadPage, lint, minimumVersion, version } from "./buf";
 import { isError } from "./errors";
 import { parseLines, Warning } from "./parser";
 import { format, less } from "./version";
@@ -41,6 +35,9 @@ export function activate(context: vscode.ExtensionContext) {
         });
       return;
     }
+    // Don't check for latest version right now,
+    // adds a lot of overhead to keep updated
+    /*
     if (less(binaryVersion, latestVersion)) {
       vscode.window
         .showInformationMessage(
@@ -54,6 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.env.openExternal(vscode.Uri.parse(downloadPage));
         });
     }
+    */
   }
 
   const diagnosticCollection = vscode.languages.createDiagnosticCollection(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,61 @@
 import * as vscode from "vscode";
-import { lint } from "./buf";
+import {
+  downloadPage,
+  latestVersion,
+  lint,
+  minimumVersion,
+  version,
+} from "./buf";
 import { isError } from "./errors";
 import { parseLines, Warning } from "./parser";
+import { format, less } from "./version";
 
 export function activate(context: vscode.ExtensionContext) {
+  const binaryPath = vscode.workspace
+    .getConfiguration("buf")!
+    .get<string>("binaryPath");
+  if (binaryPath === undefined) {
+    console.log("buf binary path was not set");
+    return;
+  }
+
+  const binaryVersion = version(binaryPath);
+  if (isError(binaryVersion)) {
+    vscode.window.showInformationMessage(
+      `Failed to get buf version: ${binaryVersion.errorMessage}`
+    );
+  } else {
+    if (less(binaryVersion, minimumVersion)) {
+      vscode.window
+        .showErrorMessage(
+          `This version of vscode-buf requires at least version ${format(
+            minimumVersion
+          )} of buf.`,
+          "Go to download page"
+        )
+        .then((selection: string | undefined) => {
+          if (selection === undefined || selection !== "Go to download page") {
+            return;
+          }
+          vscode.env.openExternal(vscode.Uri.parse(downloadPage));
+        });
+      return;
+    }
+    if (less(binaryVersion, latestVersion)) {
+      vscode.window
+        .showInformationMessage(
+          `A new version of buf is available (${format(latestVersion)}).`,
+          "Go to download page"
+        )
+        .then((selection: string | undefined) => {
+          if (selection === undefined || selection !== "Go to download page") {
+            return;
+          }
+          vscode.env.openExternal(vscode.Uri.parse(downloadPage));
+        });
+    }
+  }
+
   const diagnosticCollection = vscode.languages.createDiagnosticCollection(
     "vscode-buf.lint"
   );

--- a/src/test/suite/version.test.ts
+++ b/src/test/suite/version.test.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as version from "../../version";
+
+suite("Version Test Suite", () => {
+  vscode.window.showInformationMessage("Start all version tests.");
+
+  test("Parses simple version successfully", () => {
+    const warnings = version.parse("0.33.0");
+    const want = {
+      major: 0,
+      minor: 33,
+      patch: 0,
+    };
+    assert.deepStrictEqual(warnings, want);
+  });
+
+  test("Parses dev version successfully", () => {
+    const result = version.parse("1.34.15-dev");
+    const want = {
+      major: 1,
+      minor: 34,
+      patch: 15,
+    };
+    assert.deepStrictEqual(result, want);
+  });
+
+  test("Orders major versions successfully", () => {
+    const v1 = {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    };
+    const v2 = {
+      major: 0,
+      minor: 1,
+      patch: 2,
+    };
+    assert.strictEqual(version.less(v1, v2), false);
+    assert.strictEqual(version.less(v2, v1), true);
+  });
+
+  test("Orders minor versions successfully", () => {
+    const v1 = {
+      major: 0,
+      minor: 2,
+      patch: 0,
+    };
+    const v2 = {
+      major: 0,
+      minor: 1,
+      patch: 1,
+    };
+    assert.strictEqual(version.less(v1, v2), false);
+    assert.strictEqual(version.less(v2, v1), true);
+  });
+
+  test("Orders patch versions successfully", () => {
+    const v1 = {
+      major: 1,
+      minor: 1,
+      patch: 1,
+    };
+    const v2 = {
+      major: 1,
+      minor: 1,
+      patch: 0,
+    };
+    assert.strictEqual(version.less(v1, v2), false);
+    assert.strictEqual(version.less(v2, v1), true);
+  });
+
+  test("Orders equal versions successfully", () => {
+    const v1 = {
+      major: 1,
+      minor: 1,
+      patch: 1,
+    };
+    assert.strictEqual(version.less(v1, v1), false);
+  });
+
+  test("Formats versions successfully", () => {
+    const v1 = {
+      major: 1,
+      minor: 34,
+      patch: 15,
+    };
+    const result = version.format(v1);
+    assert.strictEqual(result, "v1.34.15");
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,65 @@
+import { Error } from "./errors";
+
+const versionRegexp = /^(\d+)\.(\d+).(\d+)(-dev)?$/;
+
+export interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export const less = (first: Version, second: Version): boolean => {
+  if (first.major < second.major) {
+    return true;
+  }
+  if (first.major === second.major && first.minor < second.minor) {
+    return true;
+  }
+  return (
+    first.major === second.major &&
+    first.minor === second.minor &&
+    first.patch < second.patch
+  );
+};
+
+export const format = (version: Version): string => {
+  return `v${version.major}.${version.minor}.${version.patch}`;
+};
+
+export const parse = (versionString: string): Version | Error => {
+  const match = versionString.match(versionRegexp);
+  if (match === null || match.length < 4) {
+    return {
+      errorMessage: `failed to parse version output: ${versionString}`,
+    };
+  }
+  let major = 0;
+  try {
+    major = parseInt(match[1]);
+  } catch {
+    return {
+      errorMessage: "failed to parse major version",
+    };
+  }
+  let minor = 0;
+  try {
+    minor = parseInt(match[2]);
+  } catch {
+    return {
+      errorMessage: "failed to parse minor version",
+    };
+  }
+  let patch = 0;
+  try {
+    patch = parseInt(match[3]);
+  } catch {
+    return {
+      errorMessage: "failed to parse patch version",
+    };
+  }
+  return {
+    major: major,
+    minor: minor,
+    patch: patch,
+  };
+};


### PR DESCRIPTION
We now prompt a user whenever a new version of buf is available, or if their currently running version is too low.

![image](https://user-images.githubusercontent.com/6604151/103478271-3e0b0780-4dbd-11eb-92a6-b655bade5b6c.png)

![image](https://user-images.githubusercontent.com/6604151/103478291-6dba0f80-4dbd-11eb-9025-3f44cf12c1d5.png)


Note that, as written, this will require us to update the plugin every time we release a new version of `buf`. We may want to have some way for the plugin to make a HTTP request to see what the latest version is instead.