### PR TITLE
Update min version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ for detailed installation instructions.
 
 Currently only supports linting but expect new features to be added soon!
 
-- Lints your protobuf files using `buf check lint`. It checks your currently opened file
+- Lints your protobuf files using `buf lint`. It checks your currently opened file
   whenever you save it.
 
   ![Lint errors](./lint_errors.png)
@@ -27,6 +27,10 @@ This extension contributes the following settings:
 
 ## Changelog
 
+- v0.2.0
+  - Update minimum required version to v0.34.0
+- v0.1.3
+  - Update logo
 - v0.1.0
   - Add version check and download link
 - v0.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "vscode-buf",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.1.3",
+			"version": "0.2.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@types/glob": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-buf",
 	"displayName": "Buf",
 	"description": "Visual Studio Code support for Buf",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"icon": "logo.png",
 	"publisher": "bufbuild",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
 		"workspaceContains:**/buf.lock",
 		"workspaceContains:**/buf.mod",
 		"workspaceContains:**/buf.work",
-		"workspaceContains:**/buf.gen"
+		"workspaceContains:**/buf.gen",
+		"workspaceContains:**/buf.gen.yaml",
+		"workspaceContains:**/buf.work.yaml"
 	],
 	"contributes": {
 		"commands": [

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -7,16 +7,16 @@ import { parse, Version } from "./version";
 /*
 export const latestVersion = {
   major: 0,
-  minor: 33,
+  minor: 55,
   patch: 0,
 };
 */
 
 export const minimumVersion = {
   major: 0,
-  // 0.31.0 was when we released --path
-  // https://groups.google.com/g/bufbuild-announce/c/5FRMd4Pm3Eo/m/p9579qKZAwAJ
-  minor: 31,
+  // 0.34.0 was when we moved "buf check lint" to "buf lint"
+  // https://github.com/bufbuild/buf/releases/tag/v0.34.0
+  minor: 34,
   patch: 0,
 };
 
@@ -29,7 +29,7 @@ export const lint = (
 ): string[] | Error => {
   const output = child_process.spawnSync(
     binaryPath,
-    ["check", "lint", "--path", filePath, "--error-format=json"],
+    ["lint", "--path", filePath, "--error-format=json"],
     {
       encoding: "utf-8",
       cwd: cwd,

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -7,7 +7,7 @@ import { parse, Version } from "./version";
 /*
 export const latestVersion = {
   major: 0,
-  minor: 55,
+  minor: 56,
   patch: 0,
 };
 */


### PR DESCRIPTION
We update the minimum version requirement so that we can stop using `buf check lint` and move to `buf lint` instead.



Fixes #15