### PR TITLE
Change `--version` to read from both `stdout` and `stderr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This extension contributes the following settings:
 
 ## Changelog
 
+- v0.3.0
+  - Change `--version` to read from both `stdout` and `stderr`
 - v0.2.0
   - Update minimum required version to v0.34.0
 - v0.1.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "vscode-buf",
 			"version": "0.2.0",
 			"license": "Apache-2.0",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-buf",
 	"displayName": "Buf",
 	"description": "Visual Studio Code support for Buf",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"icon": "logo.png",
 	"publisher": "bufbuild",
 	"repository": {

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -51,5 +51,8 @@ export const version = (binaryPath: string): Version | Error => {
   if (output.error !== undefined) {
     return { errorMessage: output.error.message };
   }
+  if (output.stderr.trim() !== "") {
+    return parse(output.stderr.trim());
+  }
   return parse(output.stdout.trim());
 };

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -51,5 +51,5 @@ export const version = (binaryPath: string): Version | Error => {
   if (output.error !== undefined) {
     return { errorMessage: output.error.message };
   }
-  return parse(output.stderr.trim());
+  return parse(output.stdout.trim());
 };


### PR DESCRIPTION
A change in the `buf` cli moved the output of the `--version` flag to `stdout`.
Fixes #17.﻿
