### PR TITLE
Use proto file reference to resolve lint file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This extension contributes the following settings:
 
 ## Changelog
 
+- v0.4.0
+  - Use single file reference to resolve lint file from any path
 - v0.3.1
   - Accept v1.0.0-rc1 in version parser
 - v0.3.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-buf",
 	"displayName": "Buf",
 	"description": "Visual Studio Code support for Buf",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"icon": "logo.png",
 	"publisher": "bufbuild",
 	"repository": {

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -29,7 +29,7 @@ export const lint = (
 ): string[] | Error => {
   const output = child_process.spawnSync(
     binaryPath,
-    ["lint", "--path", filePath, "--error-format=json"],
+    ["lint", filePath, "--error-format=json"],
     {
       encoding: "utf-8",
       cwd: cwd,


### PR DESCRIPTION
This is pending the merge of https://github.com/bufbuild/buf/pull/608 which implements a single proto file reference
for the lint command, allowing users to open up the proto file from various locations and still be able to lint
the target file path.﻿
