### PR TITLE
Add 'buf format'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-buf",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-buf",
-			"version": "0.4.0",
+			"version": "0.5.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@types/glob": "^7.1.3",
@@ -23,7 +23,7 @@
 				"vscode-test": "^1.4.0"
 			},
 			"engines": {
-				"vscode": "^1.51.0"
+				"vscode": "^1.63.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"protocol buffers",
 		"buf",
 		"bufbuild",
-		"lint"
+		"lint",
+		"format"
 	],
 	"activationEvents": [
 		"workspaceContains:**/*.proto",
@@ -85,7 +86,7 @@
 				],
 				"aliases": [
 					"Protocol Buffers",
-					"Protobufs"
+					"Protobuf"
 				]
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-buf",
 	"displayName": "Buf",
 	"description": "Visual Studio Code support for Buf",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"icon": "logo.png",
 	"publisher": "bufbuild",
 	"repository": {
@@ -23,6 +23,7 @@
 		"vscode": "^1.63.0"
 	},
 	"categories": [
+		"Formatters",
 		"Linters"
 	],
 	"keywords": [
@@ -31,6 +32,7 @@
 		"protobuf",
 		"protocol buffers",
 		"buf",
+		"bufbuild",
 		"lint"
 	],
 	"activationEvents": [
@@ -61,6 +63,11 @@
 				}
 			}
 		},
+		"configurationDefaults": {
+			"[proto]": {
+				"editor.formatOnSave": true
+			}
+		},
 		"languages": [
 			{
 				"id": "yaml",
@@ -69,6 +76,16 @@
 					"buf.mod",
 					"buf.work",
 					"buf.gen"
+				]
+			},
+			{
+				"id": "proto",
+				"extensions": [
+					".proto"
+				],
+				"aliases": [
+					"Protocol Buffers",
+					"Protobufs"
 				]
 			}
 		]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { downloadPage, lint, minimumVersion, version } from "./buf";
 import { isError } from "./errors";
+import { Formatter } from "./formatter";
 import { parseLines, Warning } from "./parser";
 import { format, less } from "./version";
 
@@ -124,6 +125,7 @@ export function activate(context: vscode.ExtensionContext) {
     diagnosticCollection.set(document.uri, diagnostics);
   };
 
+  context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('proto', new Formatter(binaryPath)));
   context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(doLint));
   context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(doLint));
   context.subscriptions.push(

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -41,10 +41,10 @@ export class Formatter implements vscode.DocumentFormattingEditProvider {
         token: vscode.CancellationToken
     ): Thenable<vscode.TextEdit[]> {
         return new Promise<vscode.TextEdit[]>((resolve, reject) => {
-            const cwd = path.join(os.tmpdir(), this.randomId())
+            const cwd = path.join(os.tmpdir(), this.randomId());
             vscode.workspace.fs.createDirectory(vscode.Uri.file(cwd)).then(() => {
                 // Buf format expects a `.proto` file, so add unique id as a prefix.
-                const backupFile = path.join(cwd, this.randomId() + "-" + path.basename(document.fileName))
+                const backupFile = path.join(cwd, this.randomId() + "-" + path.basename(document.fileName));
                 vscode.workspace.fs.writeFile(vscode.Uri.file(backupFile), new TextEncoder().encode(document.getText())).then(() => {
                     let stdout = '';
                     let stderr = '';
@@ -71,8 +71,8 @@ export class Formatter implements vscode.DocumentFormattingEditProvider {
                         ];
                         return resolve(textEdits);
                     });
-                })
+                });
             });
-        })
+        });
     }
 }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,67 @@
+import * as cp from "child_process";
+import * as path from "path";
+import * as vscode from "vscode";
+
+export class Formatter implements vscode.DocumentFormattingEditProvider {
+    readonly binaryPath: string = '';
+
+    constructor(binaryPath: string) {
+        if (!binaryPath || binaryPath.length === 0) {
+            throw new Error('binaryPath is required to construct a formatter');
+        }
+        this.binaryPath = binaryPath;
+    }
+
+    public provideDocumentFormattingEdits(
+        document: vscode.TextDocument,
+        // @ts-ignore: The formatter doesn't have any options, but we need to implement the interface.
+        options: vscode.FormattingOptions,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.TextEdit[]> {
+        if (vscode.window.visibleTextEditors.every((e) => e.document.fileName !== document.fileName)) {
+            return [];
+        }
+        return this.runFormatter(document, token).then(
+            (edits) => edits,
+            (err) => {
+                console.log(err);
+                return Promise.reject('Check the console in dev tools to find errors when formatting.');
+            }
+        );
+    }
+
+    private runFormatter(
+        document: vscode.TextDocument,
+        // @ts-ignore: TODO: Use the CancellationToken.
+        token: vscode.CancellationToken
+    ): Thenable<vscode.TextEdit[]> {
+        return new Promise<vscode.TextEdit[]>((resolve, reject) => {
+            const cwd = path.dirname(document.fileName);
+            let stdout = '';
+            let stderr = '';
+
+            // Use spawn instead of exec to avoid maxBufferExceeded error
+            const p = cp.spawn(this.binaryPath, [document.fileName], { cwd });
+            // TODO: We need to use the CancellationToken.
+            p.stdout.setEncoding('utf8');
+            p.stdout.on('data', (data: any) => (stdout += data));
+            p.stderr.on('data', (data: any) => (stderr += data));
+            p.on('error', (err: any) => {
+            if (err && (<any>err).code === 'ENOENT') {
+                return reject();
+            }
+            });
+            p.on('close', (code: number) => {
+                if (code !== 0) {
+                    return reject(stderr);
+                }
+                const fileStart = new vscode.Position(0, 0);
+                const fileEnd = document.lineAt(document.lineCount - 1).range.end;
+                const textEdits: vscode.TextEdit[] = [
+                    new vscode.TextEdit(new vscode.Range(fileStart, fileEnd), stdout)
+                ];
+                return resolve(textEdits);
+            });
+        });
+    }
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -33,7 +33,7 @@ export class Formatter implements vscode.DocumentFormattingEditProvider {
     }
 
     private randomId(): string {
-        return (Math.floor(Math.random() * 100000)).toString()
+        return (Math.floor(Math.random() * 100000000)).toString();
     }
 
     private runFormatter(
@@ -41,7 +41,7 @@ export class Formatter implements vscode.DocumentFormattingEditProvider {
         token: vscode.CancellationToken
     ): Thenable<vscode.TextEdit[]> {
         return new Promise<vscode.TextEdit[]>((resolve, reject) => {
-            const cwd = path.join(os.tmpdir(), this.randomId());
+            const cwd = path.join(os.tmpdir(), "vscode-buf-" + this.randomId());
             vscode.workspace.fs.createDirectory(vscode.Uri.file(cwd)).then(() => {
                 // Buf format expects a `.proto` file, so add unique id as a prefix.
                 const backupFile = path.join(cwd, this.randomId() + "-" + path.basename(document.fileName));


### PR DESCRIPTION
This doesn't work, but putting this up as-is since I don't have time to finish right now. This adds a [`DocumentFormattingEditProvider`](https://code.visualstudio.com/api/references/vscode-api#DocumentFormattingEditProvider) that adds `buf format` to the extension. 

A lot of the code here is referenced from Go's old [`goFormat.ts`](https://github.com/golang/vscode-go/blob/0fa41b1c6e4217cc68a61bc97a7cabd34655e3cb/src/language/legacy/goFormat.ts).