### PR TITLE
[WIP] Add language server support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@types/glob": "^7.1.3",
 				"@types/mocha": "^9.0.0",
 				"@types/node": "^12.11.7",
-				"@types/vscode": "^1.63.0",
+				"@types/vscode": "^1.67.0",
 				"@typescript-eslint/eslint-plugin": "^4.33.0",
 				"@typescript-eslint/parser": "^4.33.0",
 				"eslint": "^7.9.0",
@@ -258,9 +258,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.63.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
-			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
+			"version": "1.67.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -4091,9 +4091,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.63.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.0.tgz",
-			"integrity": "sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==",
+			"version": "1.67.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"mocha": "^8.1.3",
 				"typescript": "^4.5.4",
 				"vsce": "^1.96.2",
+				"vscode-languageclient": "^8.0.2",
 				"vscode-test": "^1.4.0"
 			},
 			"engines": {
@@ -3626,6 +3627,45 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageclient": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"dev": true,
+			"dependencies": {
+				"minimatch": "^3.0.4",
+				"semver": "^7.3.5",
+				"vscode-languageserver-protocol": "3.17.2"
+			},
+			"engines": {
+				"vscode": "^1.67.0"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"dev": true,
+			"dependencies": {
+				"vscode-jsonrpc": "8.0.2",
+				"vscode-languageserver-types": "3.17.2"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+			"dev": true
+		},
 		"node_modules/vscode-test": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -6573,6 +6613,39 @@
 					}
 				}
 			}
+		},
+		"vscode-jsonrpc": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+			"dev": true
+		},
+		"vscode-languageclient": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^3.0.4",
+				"semver": "^7.3.5",
+				"vscode-languageserver-protocol": "3.17.2"
+			}
+		},
+		"vscode-languageserver-protocol": {
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"dev": true,
+			"requires": {
+				"vscode-jsonrpc": "8.0.2",
+				"vscode-languageserver-types": "3.17.2"
+			}
+		},
+		"vscode-languageserver-types": {
+			"version": "3.17.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
+			"dev": true
 		},
 		"vscode-test": {
 			"version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"mocha": "^8.1.3",
 		"typescript": "^4.5.4",
 		"vsce": "^1.96.2",
+		"vscode-languageclient": "^8.0.2",
 		"vscode-test": "^1.4.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		}
 	],
 	"engines": {
-		"vscode": "^1.63.0"
+		"vscode": "^1.67.0"
 	},
 	"categories": [
 		"Formatters",
@@ -105,7 +105,7 @@
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^9.0.0",
 		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.63.0",
+		"@types/vscode": "^1.67.0",
 		"@typescript-eslint/eslint-plugin": "^4.33.0",
 		"@typescript-eslint/parser": "^4.33.0",
 		"eslint": "^7.9.0",


### PR DESCRIPTION
This adds support for the recently released https://github.com/bufbuild/buf-language-server.

This is based on the [VSCode Language Extension Guide](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide) and the [sample language server client](https://github.com/microsoft/vscode-extension-samples/blob/main/lsp-sample/client/src/extension.ts) implementation.