### PR TITLE
Prepare version v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This extension contributes the following settings:
 
 ## Changelog
 
+- v0.5.1
+  - Fix an issue with setting buf format as the default formatter for proto3 files.
 - v0.5.0
   - Add formatting through using buf format. Defaults to format on save.
 - v0.4.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-buf",
   "displayName": "Buf",
   "description": "Visual Studio Code support for Buf",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "icon": "logo.png",
   "publisher": "bufbuild",
   "repository": {


### PR DESCRIPTION
Diff since last release: https://github.com/bufbuild/vscode-buf/compare/d0e46fff849928e5bd1fcb05fe13aa9c69e331af...svanburen/v0.5.1. Mostly dependabot updates and #162.