### PR TITLE
Return diagnostics only for the current file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,7 @@ export function activate(context: vscode.ExtensionContext) {
       (warning: Warning): Boolean => {
         return warning.path === document.uri.fsPath;
       }
-    )
+    );
     const diagnostics = warningsForThisDocument.map(
       (error: Warning): vscode.Diagnostic => {
         // VSC lines and columns are 0 indexed, so we need to subtract

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,12 @@ export function activate(context: vscode.ExtensionContext) {
       console.log(warnings);
       return;
     }
-    const diagnostics = warnings.map(
+    const warningsForThisDocument = warnings.filter(
+      (warning: Warning): Boolean => {
+        return warning.path == document.uri.fsPath
+      }
+    )
+    const diagnostics = warningsForThisDocument.map(
       (error: Warning): vscode.Diagnostic => {
         // VSC lines and columns are 0 indexed, so we need to subtract
         const range = new vscode.Range(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
     const warningsForThisDocument = warnings.filter(
       (warning: Warning): Boolean => {
-        return warning.path == document.uri.fsPath
+        return warning.path === document.uri.fsPath;
       }
     )
     const diagnostics = warningsForThisDocument.map(


### PR DESCRIPTION
This fixes the problem where in one proto file you see highlights for lint errors from all other files.

In the example below, `foo_x`'s highlight also appears in `bar.proto` and `bar_x`'s highlight in `foo.proto`. 

| Before | After | 
| :---: | :---: |
| <img width="552" alt="before" src="https://github.com/bufbuild/vscode-buf/assets/73540835/0cbf15e4-fd68-47e8-8490-c0c382dce128"> | <img width="587" alt="after" src="https://github.com/bufbuild/vscode-buf/assets/73540835/ee92b505-e29d-43d5-ae64-a5b846756e1c">| 

