### PR TITLE
Output errors to console instead of dev console

### DIFF
--- a/src/buf.ts
+++ b/src/buf.ts
@@ -38,7 +38,7 @@ export const lint = (
     }
   );
   // If the command fails to run, such as a failed module/workspace build, return the error.
-  if (output.status == 1)  {
+  if (output.status === 1)  {
     return output.stderr.trim().split("\n");
   }
   // If the command succeeds with no lint failures and an empty output will be returned.

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -37,13 +37,12 @@ export const lint = (
       shell: process.platform === "win32",
     }
   );
-  if (output.error !== undefined) {
-    return { errorMessage: output.error.message };
+  // If the command fails to run, such as a failed module/workspace build, return the error.
+  if (output.status == 1)  {
+    return output.stderr.trim().split("\n");
   }
-  if (output.status !== null && output.status === 0) {
-    return [];
-  }
-  return output.stdout.trim().split("\n");
+  // If the command succeeds with no lint failures and an empty output will be returned.
+  return output.stdout.trim().split("\n").filter((s) => s.trim().length > 0);
 };
 
 export const version = (binaryPath: string): Version | Error => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   const diagnosticCollection =
     vscode.languages.createDiagnosticCollection("vscode-buf.lint");
+  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
+
   const doLint = (document: vscode.TextDocument) => {
     if (!document.uri.path.endsWith(".proto")) {
       return;
@@ -82,7 +84,8 @@ export function activate(context: vscode.ExtensionContext) {
     }
     const warnings = parseLines(lines);
     if (isError(warnings)) {
-      console.log(warnings);
+      outputChannel.appendLine(warnings.errorMessage);
+      outputChannel.show();
       return;
     }
     const warningsForThisDocument = warnings.filter(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,8 @@ import { format, less } from "./version";
 import { getBinaryPath } from "./get-binary-path";
 
 export function activate(context: vscode.ExtensionContext) {
-  const { binaryPath } = getBinaryPath();
+  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
+  const { binaryPath } = getBinaryPath(outputChannel);
   if (binaryPath === undefined) {
     return;
   }
@@ -57,14 +58,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   const diagnosticCollection =
     vscode.languages.createDiagnosticCollection("vscode-buf.lint");
-  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
 
   const doLint = (document: vscode.TextDocument) => {
     if (!document.uri.path.endsWith(".proto")) {
       return;
     }
 
-    const { binaryPath, cwd } = getBinaryPath();
+    const { binaryPath, cwd } = getBinaryPath(outputChannel);
     if (binaryPath === undefined) {
       return;
     }
@@ -112,7 +112,7 @@ export function activate(context: vscode.ExtensionContext) {
     diagnosticCollection.set(document.uri, diagnostics);
   };
 
-  const formatter = new Formatter(binaryPath);
+  const formatter = new Formatter(binaryPath, outputChannel);
   context.subscriptions.push(
     vscode.languages.registerDocumentFormattingEditProvider("proto", formatter)
   );

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,14 +5,15 @@ import * as vscode from "vscode";
 import { TextEncoder } from "util";
 
 export class Formatter implements vscode.DocumentFormattingEditProvider {
-    outputChannel = vscode.window.createOutputChannel("Buf", "console");
+    outputChannel: vscode.OutputChannel | undefined;
     readonly binaryPath: string = '';
 
-    constructor(binaryPath: string) {
+    constructor(binaryPath: string, outputChannel: vscode.OutputChannel) {
         if (!binaryPath || binaryPath.length === 0) {
             throw new Error('binaryPath is required to construct a formatter');
         }
         this.binaryPath = binaryPath;
+        this.outputChannel = outputChannel;
     }
 
     public provideDocumentFormattingEdits(
@@ -27,8 +28,8 @@ export class Formatter implements vscode.DocumentFormattingEditProvider {
         return this.runFormatter(document, token).then(
             (edits) => edits,
             (err) => {
-                this.outputChannel.appendLine(err);
-                this.outputChannel.show();
+                this.outputChannel?.appendLine(err);
+                this.outputChannel?.show();
                 return Promise.reject('Check the console to find errors when formatting.');
             }
         );

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { TextEncoder } from "util";
 
 export class Formatter implements vscode.DocumentFormattingEditProvider {
+    outputChannel = vscode.window.createOutputChannel("Buf", "console");
     readonly binaryPath: string = '';
 
     constructor(binaryPath: string) {
@@ -26,8 +27,9 @@ export class Formatter implements vscode.DocumentFormattingEditProvider {
         return this.runFormatter(document, token).then(
             (edits) => edits,
             (err) => {
-                console.log(err);
-                return Promise.reject('Check the console in dev tools to find errors when formatting.');
+                this.outputChannel.appendLine(err);
+                this.outputChannel.show();
+                return Promise.reject('Check the console to find errors when formatting.');
             }
         );
     }

--- a/src/get-binary-path.ts
+++ b/src/get-binary-path.ts
@@ -7,23 +7,28 @@ const defaultBinaryPath =
   pkg.contributes.configuration.properties["buf.binaryPath"].default;
 
 const getWorkspaceFolderFsPath = () => {
+  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
   if (vscode.workspace.workspaceFolders === undefined) {
-    console.log("workspace folders was undefined");
+    outputChannel.appendLine("workspace folders was undefined");
+    outputChannel.show();
     return;
   }
   if (vscode.workspace.workspaceFolders.length === 0) {
-    console.log("workspace folders was not set");
+    outputChannel.appendLine("workspace folders was not set");
+    outputChannel.show();
     return;
   }
   const uri = vscode.workspace.workspaceFolders[0].uri;
   if (uri.scheme !== "file") {
-    console.log("uri was not file: ", uri.scheme);
+    outputChannel.appendLine(`uri was not file: ${uri.scheme}`);
+    outputChannel.show();
     return;
   }
   return uri.fsPath;
 };
 
 export const getBinaryPath = () => {
+  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
   const workspaceFolderFsPath = getWorkspaceFolderFsPath();
   if (workspaceFolderFsPath === undefined) {
     return {};
@@ -32,7 +37,8 @@ export const getBinaryPath = () => {
     .getConfiguration("buf")!
     .get<string>("binaryPath");
   if (binaryPath === undefined) {
-    console.log("buf binary path was not set");
+    outputChannel.appendLine("buf binary path was not set");
+    outputChannel.show();
     return {};
   }
 
@@ -41,7 +47,8 @@ export const getBinaryPath = () => {
     binaryPath = path.join(workspaceFolderFsPath, binaryPath);
 
     if (!existsSync(binaryPath)) {
-      console.log("buf binary path does not exist: ", binaryPath);
+      outputChannel.appendLine(`buf binary path does not exist: ${binaryPath}`);
+      outputChannel.show();
       return {};
     }
   }

--- a/src/get-binary-path.ts
+++ b/src/get-binary-path.ts
@@ -6,8 +6,7 @@ import pkg from "../package.json";
 const defaultBinaryPath =
   pkg.contributes.configuration.properties["buf.binaryPath"].default;
 
-const getWorkspaceFolderFsPath = () => {
-  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
+const getWorkspaceFolderFsPath = (outputChannel: vscode.OutputChannel) => {
   if (vscode.workspace.workspaceFolders === undefined) {
     outputChannel.appendLine("workspace folders was undefined");
     outputChannel.show();
@@ -27,9 +26,8 @@ const getWorkspaceFolderFsPath = () => {
   return uri.fsPath;
 };
 
-export const getBinaryPath = () => {
-  const outputChannel = vscode.window.createOutputChannel("Buf", "console");
-  const workspaceFolderFsPath = getWorkspaceFolderFsPath();
+export const getBinaryPath = (outputChannel: vscode.OutputChannel) => {
+  const workspaceFolderFsPath = getWorkspaceFolderFsPath(outputChannel);
   if (workspaceFolderFsPath === undefined) {
     return {};
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -29,15 +29,12 @@ export const parseLines = (errorLines: string[]): Warning[] | Error => {
   for (let index = 0; index < errorLines.length; index++) {
     try {
       const warning = JSON.parse(errorLines[index]);
-      if (!isWarning(warning)) {
-        return {
-          errorMessage: `failed to parse "${errorLines[index]}" as warning`,
-        };
+      if (isWarning(warning)) {
+        warnings.push(warning);
       }
-      warnings.push(warning);
     } catch (error) {
       return {
-        errorMessage: `failed to parse "${errorLines[index]}" as warning: ${error}`,
+        errorMessage: `${errorLines.join(",")}`,
       };
     }
   }

--- a/src/test/buf.test.ts
+++ b/src/test/buf.test.ts
@@ -8,6 +8,7 @@ import path from "path";
 
 suite("Buf CLI tests", () => {
   vscode.window.showInformationMessage("Start all tests.");
+  const outputChannel = vscode.window.createOutputChannel("Buf-test", "console");
 
   test("Default path succeeds when buf is installed", async () => {
     const version = buf.version("buf");
@@ -19,7 +20,7 @@ suite("Buf CLI tests", () => {
   });
 
   test("Relative path loaded from config", async () => {
-    const { binaryPath } = getBinaryPath();
+    const { binaryPath } = getBinaryPath(outputChannel);
     assert.ok(binaryPath);
     const version = buf.version(binaryPath);
     if ("errorMessage" in version) {
@@ -33,7 +34,7 @@ suite("Buf CLI tests", () => {
     let storedPath: string | undefined;
 
     setup(() => {
-      const { cwd } = getBinaryPath();
+      const { cwd } = getBinaryPath(outputChannel);
       storedPath = vscode.workspace
         .getConfiguration("buf")
         .get<string>("binaryPath");
@@ -50,7 +51,7 @@ suite("Buf CLI tests", () => {
     });
 
     test("version", async () => {
-      const { binaryPath } = getBinaryPath();
+      const { binaryPath } = getBinaryPath(outputChannel);
       assert.ok(binaryPath);
       const version = buf.version(binaryPath);
       if ("errorMessage" in version) {


### PR DESCRIPTION
In the past, we were not correctly surfacing build errors to users from `buf lint` in the console, and were instead parsed and eaten in the dev console.
This PR directs all previous `console.log` statements to the user-facing output console and properly surfaces the build errors, e.g.:

<img width="1172" alt="Screenshot 2024-12-04 at 15 22 21" src="https://github.com/user-attachments/assets/752d25a5-e8ad-499d-ac61-b9a43068d320">

This will make it easier for users to debugging build failures through the extension much easier.

Fixes #347