### PR TITLE
BUG FIX: Update buf.ts to allow paths with spaces on them

### DIFF
--- a/src/buf.ts
+++ b/src/buf.ts
@@ -30,7 +30,7 @@ export const lint = (
 ): string[] | Error => {
   const output = child_process.spawnSync(
     binaryPath,
-    ["lint", filePath + "#include_package_files=true", "--error-format=json"],
+    ["lint", `"${filePath}"` + "#include_package_files=true", "--error-format=json"],
     {
       encoding: "utf-8",
       cwd: cwd,


### PR DESCRIPTION
Previously the Buf Lint extension would give the output saying the command received 2 arguments when it expected 1.
This happened because of path with space (this is somewhat common with Windows).

Before:
`buf lint C:\Users\Daniel Pereira\.... --opts`

After:
`buf lint "C:\Users\Daniel Pereira\...." --opts`

Just a small oversight :)