### PR TITLE
Set shell: true for all commands

### DIFF
--- a/src/buf.ts
+++ b/src/buf.ts
@@ -32,7 +32,7 @@ export const lint = (
     binaryPath,
     [
       "lint",
-      `"${filePath}"` + "#include_package_files=true",
+      `'${filePath}'` + "#include_package_files=true",
       "--error-format=json",
     ],
     {

--- a/src/buf.ts
+++ b/src/buf.ts
@@ -38,7 +38,7 @@ export const lint = (
     {
       encoding: "utf-8",
       cwd: cwd,
-      shell: process.platform === "win32",
+      shell: true,
     }
   );
   // If the command fails to run, such as a failed module/workspace build, return the error.
@@ -55,7 +55,7 @@ export const lint = (
 export const version = (binaryPath: string): Version | Error => {
   const output = child_process.spawnSync(binaryPath, ["--version"], {
     encoding: "utf-8",
-    shell: process.platform === "win32",
+    shell: true,
   });
   if (output.error !== undefined) {
     return { errorMessage: output.error.message };


### PR DESCRIPTION
We need to set `shell: true` for all commands being run
by the extension, because they should be executed in a
shell environment. This allows for interpreting `"`, for example,
in the file path correctly.