### PR TITLE
Added features to the Makefile and Activation event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
 .DEFAULT_GOAL := package
 
-.PHONY: package
-package:
+.PHONY: check-install compile package
+package: compile
 	npm run package
 
 .PHONY: install
 install:
 	npm install
+
+.PHONY: check-install
+check-install:
+	@if [ ! -d "node_modules" ]; then \
+		echo "installing npm packages..."; \
+		npm install; \
+	fi
+
+.PHONY: compile
+compile: check-install
+	npm run compile


### PR DESCRIPTION
Added features to the Makefile to install npm packages on build if not present, and to always compile. Added a `handleProtoFileOpened` event to check and ensure the language server is running. If not, it starts it up. This helps in dev mode if a previous extension version is there. The impact is minimal if the server is running (it exits).

Please check the Makefile to be sure it meets with your standards. Hope this is helpful!