### PR TITLE
Set minimum VS Code engine version to 1.95.0

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -3,6 +3,9 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "@vscode/test-cli";
 
 /**
+ * Integration test configs.
+ *
+ * VS Code version defaults to stable.
  */
 export default defineConfig([
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "vscode": "^1.102.0"
+        "vscode": "^1.95.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.102.0"
+    "vscode": "^1.95.0"
   },
   "categories": [
     "Formatters",


### PR DESCRIPTION
@paul-sachs and I did some testing of the extension over
VS Code versions, and found that we are able to run the
extension on VS Code `1.95.0` because we depend on
features in [Node 20.18+/Electron 32](https://code.visualstudio.com/updates/v1_95#_electron-32-update).

This allows us to support installing the extension on
Windsurf, which is currently using VS Code `1.99.0`.