### PR TITLE
Run download only once for playwright tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,8 @@
     "lint": "biome lint --fix .",
     "test": "npm run test:integration && npm run test:playwright",
     "test:integration": "vscode-test",
-    "test:playwright": "node ./test/playwright/setup-script.mts && playwright test",
+    "pretest:playwright": "node ./test/playwright/setup-script.mts",
+    "test:playwright": "playwright test",
     "test:playwright:debug": "playwright test --debug --workers=1 --retries=0 --reporter=list",
     "package": "vsce package",
     "format": "biome format --write ."

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "lint": "biome lint --fix .",
     "test": "npm run test:integration && npm run test:playwright",
     "test:integration": "vscode-test",
-    "test:playwright": "playwright test",
+    "test:playwright": "node ./test/playwright/setup-script.mts &&playwright test",
     "test:playwright:debug": "playwright test --debug --workers=1 --retries=0 --reporter=list",
     "package": "vsce package",
     "format": "biome format --write ."

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "lint": "biome lint --fix .",
     "test": "npm run test:integration && npm run test:playwright",
     "test:integration": "vscode-test",
-    "test:playwright": "node ./test/playwright/setup-script.mts &&playwright test",
+    "test:playwright": "node ./test/playwright/setup-script.mts && playwright test",
     "test:playwright:debug": "playwright test --debug --workers=1 --retries=0 --reporter=list",
     "package": "vsce package",
     "format": "biome format --write ."

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,6 @@ export default defineConfig<TestOptions>({
   expect: {
     timeout: 40_000,
   },
-  globalSetup: "./test/playwright/global-setup.ts",
   projects: [
     {
       name: "VS Code insiders",

--- a/test/playwright/global-setup.ts
+++ b/test/playwright/global-setup.ts
@@ -1,5 +1,0 @@
-import { downloadAndUnzipVSCode } from "@vscode/test-electron";
-
-export default async () => {
-  await downloadAndUnzipVSCode("insiders");
-};

--- a/test/playwright/setup-script.mts
+++ b/test/playwright/setup-script.mts
@@ -1,0 +1,7 @@
+// This file is run before all tests are run and is just used to prep 
+// the environment for the tests. It is run only once regardless of how
+// many workers are invoked.
+
+import { downloadAndUnzipVSCode } from "@vscode/test-electron";
+
+await downloadAndUnzipVSCode("insiders");


### PR DESCRIPTION
Instead of using globalSetup (which runs once per worker), we just download the vscode we want to use in a pre-test script.