### PR TITLE
Fix types package version to match engine version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.2.1",
         "@types/semver": "^7.7.0",
-        "@types/vscode": "^1.102.0",
+        "@types/vscode": "^1.95.0",
         "@types/which": "^3.0.4",
         "@vscode/test-cli": "^0.0.11",
         "@vscode/test-electron": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.2.1",
     "@types/semver": "^7.7.0",
-    "@types/vscode": "^1.102.0",
+    "@types/vscode": "^1.95.0",
     "@types/which": "^3.0.4",
     "@vscode/test-cli": "^0.0.11",
     "@vscode/test-electron": "^2.5.2",


### PR DESCRIPTION
The types package should match the engine
configuration for `vscode`.