### PR TITLE
Fix test assertion

### DIFF
--- a/test/playwright/extension.test.ts
+++ b/test/playwright/extension.test.ts
@@ -598,7 +598,7 @@ extensionTest.describe("lsp", async () => {
     await expectHover(
       page,
       "User", // LSP shows the documentation for types that have it
-      "message example.v1.User User represents a user in the system"
+      " User represents a user in the system"
     );
   });
   extensionTest.skip("lint checks", async ({ page }) => {


### PR DESCRIPTION
`buf lsp serve` on main no longer reports the literal text "<missing docs>" on missing documentation.

Ref: https://github.com/bufbuild/buf/commit/778496bce48791265c391b8e049354973aa4193f#r169016449