### PR TITLE
Deprecate breaking change detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ documentation and diagnostic hovers, and integrations with [Buf][buf] commands.
 
 - **Code navigation** - Go-to definition and documentation insets for `.proto` symbols.
 - **Syntax highlighting** - Protobuf specific color and styling of code.
-- **Code editing** - Formatting via `buf format` and annotations and hovers based on `buf lint`
-  and `buf breaking`.
+- **Code editing** - Formatting via `buf format` and annotations and hovers based on `buf lint`.
 - **Documentation hovers** - Documentation for definitions when hovering a reference.
 - **Buf command support** - Execution of `buf` CLI commands via the [Command Palette][command-palette].
 
@@ -70,17 +69,6 @@ Enable debug logs in output channels.
 
 Default: `text`
 Buf Language Server log format.
-
-### buf.checks.breaking.againstStrategy
-
-Default: `git`
-The strategy to use when checking breaking changes against a specific reference.
-
-### buf.checks.breaking.againstGitRef
-
-Default: `refs/remotes/origin/HEAD`
-The Git reference to check breaking changes against. This is only compatible when `buf.checks.breaking.againstStrategy`
-is set to `git`, otherwise it is ignored.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -207,12 +207,14 @@
             "git"
           ],
           "default": "git",
-          "description": "The strategy to use when checking breaking changes against a specific reference."
+          "description": "The strategy to use when checking breaking changes against a specific reference.",
+          "deprecationMessage": "Deprecated: breaking change detection is no longer supported in the LSP."
         },
         "buf.checks.breaking.againstGitRef": {
           "type": "string",
           "default": "refs/remotes/origin/HEAD",
-          "description": "The Git reference to check breaking changes against."
+          "description": "The Git reference to check breaking changes against.",
+          "deprecationMessage": "Deprecated: breaking change detection is no longer supported in the LSP."
         }
       }
     },


### PR DESCRIPTION
We've removed breaking change detection from the latest
version of the LSP, so we deprecate the configuration. This
hides the configuration from the settings page and provides
the deprecation message when editing `settings.json`.