### PR TITLE
Release workflow fixes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Extension
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 
 jobs:
   publish:
@@ -16,9 +16,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Run tests
-        run: npm test
 
       - name: Package extension (regular)
         if: github.event.release.prerelease == false


### PR DESCRIPTION
* Drop the testing from the release; operationally, we ought to only release from main with a green build and will include that in the release checklist
* Drop the `prereleased` type from the `on` stanza; we already have conditional logic in the workflow below that handles the prerelease case, and adding this causes duplicate workflow runs on a prerelease being published