### PR TITLE
Fix pushing commit to main from publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -13,6 +14,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
+
+      - name: Generate Github Token
+        id: generate_gh_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: 2702065
+          private-key: ${{ secrets.RELEASE_APP_TOKEN_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Install dependencies
         run: npm ci
@@ -23,11 +32,6 @@ jobs:
       - name: Package extension (pre-release)
         if: github.event.release.prerelease == true
         run: npm run package:prerelease
-
-      - name: Set up git credentials
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Publish to VS Code Marketplace (regular)
         if: github.event.release.prerelease == false
@@ -46,6 +50,8 @@ jobs:
 
       - name: Push version commit
         run: |
+          git config --global user.email "2702065+app-token-vscode-buf-release[bot]@users.noreply.github.com"
+          git config --global user.name "app-token-vscode-buf-release[bot]"
           git push origin HEAD:${{ github.event.repository.default_branch }}
 
       - name: Publish to OpenVSX (regular)


### PR DESCRIPTION
Worked with @rubensf to get an app token set up, so that we can push directly to `main` with the commit that bumps the `package.json` `version` field.

Ref: https://github.com/bufbuild/vscode-buf/actions/runs/21217015310/job/61040883831#step:10:5