### PR TITLE
Add "Programming Languages" to VS Code categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vscode": "^1.95.0"
   },
   "categories": [
+    "Programming Languages",
     "Formatters",
     "Linters"
   ],


### PR DESCRIPTION
Now that we have the LSP, I think we can extend our categories to include "Programming Languages", as we're a general extension for protobuf with syntax highlighting, building, linting, all the LSP features, etc.

Ref: https://code.visualstudio.com/api/references/extension-manifest#fields