### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: File a bug report.
+labels: Bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve VS Code Buf by filing bugs, we really appreciate it!
+        For us to investigate your issue efficiently, we need a minimal reproducible example.
+        We get lots of support requests, so please help us help you.
+        We find that the easiest way to do this is by linking to a GitHub repository with the setup of the example,
+        as well as a set of steps for us to run on this GitHub repository to reproduce the issue.
+        You can use an existing GitHub repository, or a temporary GitHub repository you create.
+
+        **If you do not provide a minimal reproducible example in a GitHub repository,
+        we will likely close your issue until a reproducible example is provided.
+        We apologize, but we have to be efficient with our support requests, and we appreciate your help.**
+
+        [This article](https://stackoverflow.com/help/minimal-reproducible-example) on minimal reproducible examples may be of use!
+
+        Please also ensure that you're running the latest version of [`buf`](https://github.com/bufbuild/buf/releases),
+        which backs many of the features provided by VS Code Buf.
+        If you're not using the latest version of `buf`,
+        most likely our first question will be "Does this reproduce if you install the latest `buf` version?"
+  - type: checkboxes
+    id: buf-version
+    attributes:
+      label: Buf Latest Version
+      description: I've reproduced this issue using the latest version of [`buf`](https://github.com/bufbuild/buf/releases).
+      options:
+        - label: I'm using the latest version of `buf`.
+          required: true
+  - type: input
+    id: github-repository
+    attributes:
+      label: GitHub repository with your minimal reproducible example (do not leave this field blank or fill out this field with "github.com/bufbuild/vscode-buf" or we will automatically close your issue, see the instructions above!)
+      description: Provide us with a link to the GitHub repository that contains the setup needed to reproduce the issue. This is a repository you create, and is required for us to investigate your issue.
+      placeholder: https://github.com/you/temp-repo-with-repro
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: steps
+      description: Please provide the steps to run from the root of this repository to reproduce the issue.
+      placeholder: |
+        code .
+        # Do <xyz> in VS Code with the Buf extension enabled.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: actual-output
+    attributes:
+      label: Output
+      description: What is the output of performing these steps?
+      placeholder: |
+        VS Code Buf showed the following text in the output: <copied text>
+    validations:
+      required: true
+  - type: textarea
+    id: expected-output
+    attributes:
+      label: Expected Output
+      description: What did you expect instead?
+      placeholder: I expected VS Code Buf to ...
+    validations:
+      required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: Anything else?
+      description: Is there any other context you'd like us to have?

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,15 @@
+name: Feature Request
+description: Let us know about a feature you'd like us to add.
+labels: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your suggestions on how to improve VS Code Buf, we really appreciate it!
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature
+      description: Tell us what you'd like to see!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-other.yml
+++ b/.github/ISSUE_TEMPLATE/3-other.yml
@@ -1,0 +1,35 @@
+name: Other
+description: Anything else.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for getting in touch, we really appreciate it!
+        If your issue isn't a bug or feature request, we'd highly recommend to talk to us on the [Buf Slack](https://buf.build/links/slack).
+        If you think the issue is more appropriate for a GitHub issue, please file it below!
+
+        If this is a question about some behavior you are witnessing, we will need a minimal reproducible example.
+        We get lots of support requests, so please help us help you.
+        We find that the easiest way to do this is by linking to a GitHub repository with the setup of the example,
+        as well as a set of steps for us to run on this GitHub repository to reproduce the issue.
+        You can use an existing GitHub repository, or a temporary GitHub repository you create.
+
+        **If this is a question about some behavior you are witnessing,
+        and you do not provide a minimal reproducible example in a GitHub repository,
+        we will likely close your issue until a reproducible example is provided.
+        We apologize, but we have to be efficient with our support requests, and we appreciate your help.**
+
+        [This article](https://stackoverflow.com/help/minimal-reproducible-example) on minimal reproducible examples may be of use!
+  - type: input
+    id: github-repository
+    attributes:
+      label: GitHub repository with your minimal reproducible example (do not leave this field blank or fill out this field with "github.com/bufbuild/vscode-buf" or we will automatically close your issue, see the instructions above!)
+      description: If this is a question about some behavior you are witnessing, provide us with a link to the GitHub repository that contains the setup needed to reproduce the issue. This is a repository you create, and is required for us to investigate your issue.
+      placeholder: https://github.com/you/temp-repo-with-repro
+  - type: textarea
+    id: feature
+    attributes:
+      label: What's up?
+      description: Tell us what's on your mind!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Disable blank issues; must go through the templates.
+blank_issues_enabled: false
+contact_links:
+  - name: Buf Slack
+    url: https://buf.build/links/slack
+    about: Join our public Slack and ask us questions!
+  - name: Buf Contact
+    url: https://buf.build/contact
+    about: General contact form


### PR DESCRIPTION
We've had some issues that largely boiled down to "I'm still on an old version of `buf` and an upgrade would have fixed my issue". This copies over the [issue templates from the `buf` repository][1], modifies them slightly, and enforces their usage in our repo. Notably, I've included specific language about attempting to reproduce with the latest version of `buf`, and added a checkbox as a part of the template to draw specific attention to it.

[1]: https://github.com/bufbuild/buf/tree/main/.github/ISSUE_TEMPLATE