### PR TITLE
Handle `buf.lock` as YAML

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,10 @@
     ],
     "languages": [
       {
+        "id": "yaml",
+        "filenames": ["buf.lock"]
+      },
+      {
         "id": "proto",
         "extensions": [
           ".proto"
@@ -178,6 +182,10 @@
       }
     ],
     "yamlValidation": [
+      {
+        "fileMatch": "buf.lock",
+        "url": "https://www.schemastore.org/buf.lock.json"
+      },
       {
         "fileMatch": "buf.yaml",
         "url": "https://www.schemastore.org/buf.json"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,9 @@
     "languages": [
       {
         "id": "yaml",
-        "filenames": ["buf.lock"]
+        "filenames": [
+          "buf.lock"
+        ]
       },
       {
         "id": "proto",


### PR DESCRIPTION
* Associate with yaml filetype
* Add JSONSchema link

We still don't want people writing to this, obviously, but makes it a better experience when viewing the file.