### PR TITLE
Add LSP support for buf config files

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -28,9 +28,15 @@ const bufFilename = os.platform() === "win32" ? "buf.exe" : "buf";
 let serverOutputChannel: vscode.OutputChannel | undefined;
 
 /**
- * A {@link vscode.DocumentSelector} for proto files.
+ * A {@link vscode.DocumentSelector} for proto and buf config files.
  */
-const protoDocumentSelector = [{ scheme: "file", language: "proto" }];
+const protoDocumentSelector = [
+  { scheme: "file", language: "proto" },
+  { scheme: "file", pattern: "**/buf.yaml" },
+  { scheme: "file", pattern: "**/buf.gen.yaml" },
+  { scheme: "file", pattern: "**/buf.policy.yaml" },
+  { scheme: "file", pattern: "**/buf.lock" },
+];
 
 /**
  * Minimum Buf version required to use LSP via `buf beta lsp`.


### PR DESCRIPTION
This will enable running `buf lsp` for the various buf configuration files. Currently targeting the v2 configuration files, which will probably be the ones we primarily add LSP features to. (Not all have LSP features yet, but I don't think it hurts anything to enable the LSP for those file types.)

Related to bufbuild/buf#4438.