### PR TITLE
Add release.yaml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]


### PR DESCRIPTION
So we can ignore Dependabot when automatically generating the CHANGELOG.

Ref: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes