### PR TITLE
Use workspace cwd in buf binary discovery

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -225,6 +225,10 @@ class BufState {
    *
    */
   public async init(ctx: vscode.ExtensionContext) {
+    // Use the first workspace folder as the cwd for binary discovery. Version managers
+    // like asdf use the cwd to resolve the correct tool version from `.tool-versions`.
+    const workspaceCwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
     let configPath = config.get<string>("commandLine.path");
     if (configPath) {
       try {
@@ -232,7 +236,7 @@ class BufState {
           configPath = getBinaryPathForRelConfigPath(configPath);
         }
         log.info(`Attempting to use configured Buf CLI path '${configPath}...`);
-        this.bufBinary = await getBufBinaryFromPath(configPath);
+        this.bufBinary = await getBufBinaryFromPath(configPath, workspaceCwd);
         log.info(
           `Using '${this.bufBinary.path}', version: ${this.bufBinary.version}.`
         );
@@ -247,7 +251,7 @@ class BufState {
 
     log.info("Looking for Buf on the system $PATH...");
     try {
-      this.bufBinary = await findBufInSystemPath();
+      this.bufBinary = await findBufInSystemPath(workspaceCwd);
     } catch (e) {
       log.info(
         `Buf not found on the OS path: ${e}, installing from releases...`
@@ -428,9 +432,18 @@ type BufBinary = {
 
 /**
  * A helper function for getting the Buf binary at the given filesystem path.
+ *
+ * @param cwd is an optional working directory for the execution. This is important for
+ * version managers like asdf that use the current working directory to resolve the
+ * correct tool version from a `.tool-versions` file.
+ *
+ * @internal
  */
-async function getBufBinaryFromPath(path: string): Promise<BufBinary> {
-  const { stdout, stderr } = await execFile(path, ["--version"]);
+export async function getBufBinaryFromPath(
+  path: string,
+  cwd?: string
+): Promise<BufBinary> {
+  const { stdout, stderr } = await execFile(path, ["--version"], { cwd });
   if (stderr) {
     throw new Error(`Error getting version of buf binary '${path}': ${stderr}`);
   }
@@ -448,11 +461,13 @@ async function getBufBinaryFromPath(path: string): Promise<BufBinary> {
 
 /**
  * A helper function for finding the Buf CLI on the system $PATH.
+ *
+ * @param cwd is an optional working directory, passed through to {@link getBufBinaryFromPath}.
  */
-async function findBufInSystemPath(): Promise<BufBinary> {
+async function findBufInSystemPath(cwd?: string): Promise<BufBinary> {
   const bufPath = await which(bufFilename, { nothrow: true });
   if (bufPath) {
-    return getBufBinaryFromPath(bufPath);
+    return getBufBinaryFromPath(bufPath, cwd);
   }
   throw new Error(`Unable to find buf binary on system $PATH`);
 }
@@ -470,14 +485,11 @@ async function installReleaseAsset(
   await fs.promises.mkdir(downloadDir, { recursive: true });
   const downloadBin = path.join(downloadDir, bufFilename);
   try {
-    // Check to see if the downloadBin already exists and if we have access to the binary.
-    await fs.promises.access(downloadBin);
-    // We await for the bufBinary to be set before returning so we can catch any errors.
     const bufBinary = await getBufBinaryFromPath(downloadBin);
     log.info(`Using buf version v${bufBinary.version} from extension cache.`);
     return bufBinary;
   } catch (e) {
-    // In the case of an error, we log, and then move on to attempt a download.
+    // Binary not in cache or not executable; proceed to download.
     log.info(`No buf binary available locally, downloading... ${e}`);
   }
   log.info(`Downloading ${asset.name} to ${downloadBin}...`);

--- a/test/unit/state.test.ts
+++ b/test/unit/state.test.ts
@@ -6,7 +6,7 @@ import { getBufBinaryFromPath } from "../../src/state";
 
 // These tests use shell scripts and only apply on Unix platforms where asdf runs.
 suite("getBufBinaryFromPath", () => {
-  before(function () {
+  suiteSetup(function () {
     if (os.platform() === "win32") {
       this.skip();
     }

--- a/test/unit/state.test.ts
+++ b/test/unit/state.test.ts
@@ -4,7 +4,14 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getBufBinaryFromPath } from "../../src/state";
 
+// These tests use shell scripts and only apply on Unix platforms where asdf runs.
 suite("getBufBinaryFromPath", () => {
+  before(function () {
+    if (os.platform() === "win32") {
+      this.skip();
+    }
+  });
+
   let tmpDir: string;
 
   setup(() => {

--- a/test/unit/state.test.ts
+++ b/test/unit/state.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBufBinaryFromPath } from "../../src/state";
+
+suite("getBufBinaryFromPath", () => {
+  let tmpDir: string;
+
+  setup(() => {
+    // Resolve symlinks so that $PWD in scripts matches what we pass as cwd.
+    // On macOS, os.tmpdir() returns /var/... but the real path is /private/var/...
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "vscode-buf-test-"))
+    );
+  });
+
+  teardown(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("parses version from stdout", async () => {
+    const script = path.join(tmpDir, "buf");
+    fs.writeFileSync(script, "#!/bin/sh\necho 1.47.2\n");
+    fs.chmodSync(script, 0o755);
+
+    const binary = await getBufBinaryFromPath(script);
+    assert.strictEqual(binary.version.toString(), "1.47.2");
+    assert.strictEqual(binary.path, script);
+  });
+
+  test("strips trailing ~patchlevel from version", async () => {
+    const script = path.join(tmpDir, "buf");
+    fs.writeFileSync(script, "#!/bin/sh\necho 1.47.2~custom\n");
+    fs.chmodSync(script, 0o755);
+
+    const binary = await getBufBinaryFromPath(script);
+    assert.strictEqual(binary.version.toString(), "1.47.2");
+  });
+
+  test("passes cwd to the subprocess", async () => {
+    // This script simulates an asdf-style shim: it outputs a version only when
+    // run in the expected directory, and fails otherwise — verifying that the
+    // cwd option is forwarded to execFile.
+    const expectedDir = path.join(tmpDir, "workspace");
+    fs.mkdirSync(expectedDir);
+
+    const script = path.join(tmpDir, "buf");
+    fs.writeFileSync(
+      script,
+      // Use single-quotes around the path so it's treated as a literal string.
+      `#!/bin/sh\nif [ "$PWD" = '${expectedDir}' ]; then echo 1.47.2; else echo "Wrong cwd: $PWD" >&2; exit 1; fi\n`
+    );
+    fs.chmodSync(script, 0o755);
+
+    // Succeeds when the correct cwd is provided.
+    const binary = await getBufBinaryFromPath(script, expectedDir);
+    assert.strictEqual(binary.version.toString(), "1.47.2");
+
+    // Fails when a different cwd is provided.
+    await assert.rejects(
+      getBufBinaryFromPath(script, tmpDir),
+      /Command failed/
+    );
+  });
+});


### PR DESCRIPTION
To support version managers like `asdf`. Fixes #616.