### PR TITLE
Consolidate buf config files into separate filetype

### DIFF
--- a/buf-config-language-configuration.json
+++ b/buf-config-language-configuration.json
@@ -1,0 +1,5 @@
+{
+  "comments": {
+    "lineComment": "#"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -140,17 +140,14 @@
         "language": "proto",
         "scopeName": "source.proto",
         "path": "./syntaxes/proto.json"
+      },
+      {
+        "language": "buf-config",
+        "scopeName": "source.buf-config",
+        "path": "./syntaxes/buf-config.json"
       }
     ],
     "jsonValidation": [
-      {
-        "fileMatch": "buf.yaml",
-        "url": "https://www.schemastore.org/buf.json"
-      },
-      {
-        "fileMatch": "buf.gen.yaml",
-        "url": "https://www.schemastore.org/buf.gen.json"
-      },
       {
         "fileMatch": "buf.work.yaml",
         "url": "https://www.schemastore.org/buf.work.json"
@@ -162,10 +159,17 @@
     ],
     "languages": [
       {
-        "id": "yaml",
+        "id": "buf-config",
         "filenames": [
+          "buf.yaml",
+          "buf.gen.yaml",
+          "buf.policy.yaml",
           "buf.lock"
-        ]
+        ],
+        "aliases": [
+          "Buf Config"
+        ],
+        "configuration": "./buf-config-language-configuration.json"
       },
       {
         "id": "proto",
@@ -184,18 +188,6 @@
       }
     ],
     "yamlValidation": [
-      {
-        "fileMatch": "buf.lock",
-        "url": "https://www.schemastore.org/buf.lock.json"
-      },
-      {
-        "fileMatch": "buf.yaml",
-        "url": "https://www.schemastore.org/buf.json"
-      },
-      {
-        "fileMatch": "buf.gen.yaml",
-        "url": "https://www.schemastore.org/buf.gen.json"
-      },
       {
         "fileMatch": "buf.work.yaml",
         "url": "https://www.schemastore.org/buf.work.json"

--- a/src/state.ts
+++ b/src/state.ts
@@ -32,10 +32,7 @@ let serverOutputChannel: vscode.OutputChannel | undefined;
  */
 const protoDocumentSelector = [
   { scheme: "file", language: "proto" },
-  { scheme: "file", pattern: "**/buf.yaml" },
-  { scheme: "file", pattern: "**/buf.gen.yaml" },
-  { scheme: "file", pattern: "**/buf.policy.yaml" },
-  { scheme: "file", pattern: "**/buf.lock" },
+  { scheme: "file", language: "buf-config" },
 ];
 
 /**

--- a/src/state.ts
+++ b/src/state.ts
@@ -30,7 +30,7 @@ let serverOutputChannel: vscode.OutputChannel | undefined;
 /**
  * A {@link vscode.DocumentSelector} for proto and buf config files.
  */
-const protoDocumentSelector = [
+const bufDocumentSelector = [
   { scheme: "file", language: "proto" },
   { scheme: "file", language: "buf-config" },
 ];
@@ -333,7 +333,7 @@ class BufState {
       args: args,
     };
     const clientOptions: lsp.LanguageClientOptions = {
-      documentSelector: protoDocumentSelector,
+      documentSelector: bufDocumentSelector,
       diagnosticCollectionName: "bufc",
       outputChannel: serverOutputChannel,
       revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,

--- a/syntaxes/buf-config.json
+++ b/syntaxes/buf-config.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.buf-config",
+  "fileTypes": [],
+  "patterns": [
+    {
+      "include": "source.yaml"
+    }
+  ]
+}


### PR DESCRIPTION
Now that the LSP is starting to support buf config files (see #608), I noticed that we're now duplicating e.g. our hover documentation with that coming from yaml-language-server.

This consolidates the various buf config files handled by the LSP into a separate filetype, `buf-config`, so that these files aren't handled by yaml-language-server and other plugins. It adds a simple language configuration so that comments still work (yaml doesn't really have matching brackets in idiomatic usage), and the syntax just inherits from yaml.