### PR TITLE
Improve extension discoverability and overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Buf for Visual Studio Code
 
-The [VS Code Buf extension][vs-code-marketplace] helps you work with [Protocol Buffers][protobuf]
-files in a much more intuitive way, adding semantic syntax highlighting, navigation, formatting,
-documentation and diagnostic hovers, and integrations with [Buf][buf] commands.
+[Buf][buf] is a [Protocol Buffers][protobuf] (Protobuf) extension for Visual Studio Code. More
+than simple syntax highlighting, it's powered by a real language server that brings IDE-grade
+editing to `.proto` files: go-to-definition, hover documentation, autocompletion, symbol rename,
+organize imports, format-on-save, and real-time lint and build diagnostics. It also understands
+[Protovalidate][protovalidate], with hovers, completions, and go-to-definition for the
+[CEL][cel] expressions in your validation rules.
+
+Buf is built by the team behind the [Buf CLI][buf], the [Buf Schema Registry][bsr],
+[Protobuf-ES][protobuf-es], and [Protovalidate][protovalidate], and core maintainers of
+[ConnectRPC][connect] - the tooling many teams rely on to build and scale their Protobuf APIs.
+
+Install it from the [VS Code Marketplace][vs-code-marketplace] or [Open VSX][open-vsx].
 
 ## Features
 
@@ -12,6 +21,8 @@ documentation and diagnostic hovers, and integrations with [Buf][buf] commands.
 - **Formatting**: Formats `.proto` files on-save.
 - **Syntax highlighting**: Code styling that provides clarity on Protobuf keywords and identifiers.
 - **Diagnostics**: Get highlights and feedback on build and lint errors as you code.
+- **Protovalidate support**: Hovers, completions, and go-to-definition for the [CEL][cel]
+  expressions in your [Protovalidate][protovalidate] validation rules.
 
 ![Preview features](./preview.gif)
 
@@ -115,13 +126,19 @@ on [Slack][slack].
 
 Offered under the [Apache 2 license][license].
 
-[buf]: https://buf.build/
 [breaking-rules]: https://buf.build/docs/breaking/rules
+[bsr]: https://buf.build/product/bsr
+[buf]: https://buf.build/home
+[cel]: https://cel.dev/
 [command-palette]: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette
-[issue]: https://github.com/bufbuild/vscode-buf/issues/new/choose
+[connect]: https://connectrpc.com/
 [intellisense]: https://code.visualstudio.com/docs/editing/intellisense
+[issue]: https://github.com/bufbuild/vscode-buf/issues/new/choose
 [license]: https://github.com/bufbuild/vscode-buf/blob/main/LICENSE
 [lint-rules]: https://buf.build/docs/lint/rules
+[open-vsx]: https://open-vsx.org/extension/bufbuild/vscode-buf
 [protobuf]: https://protobuf.dev/
+[protobuf-es]: https://github.com/bufbuild/protobuf-es
+[protovalidate]: https://protovalidate.com/
 [slack]: https://buf.build/links/slack
 [vs-code-marketplace]: https://marketplace.visualstudio.com/items?itemName=bufbuild.vscode-buf

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-buf",
-  "displayName": "Buf",
-  "description": "Visual Studio Code support for Buf",
+  "displayName": "Buf - Protobuf (.proto) & Protovalidate",
+  "description": "Protocol Buffers (proto) language support powered by the Buf language server: lint and build diagnostics, format on save, go-to-definition, hover docs, IntelliSense, and Protovalidate (CEL) editing support.",
   "version": "0.8.19",
   "icon": "logo.png",
   "publisher": "bufbuild",
@@ -28,14 +28,27 @@
     "Linters"
   ],
   "keywords": [
+    ".proto",
+    "autocomplete",
     "buf",
+    "buf schema registry",
+    "buf.yaml",
+    "buf.gen.yaml",
     "bufbuild",
+    "cel",
+    "diagnostics",
     "format",
+    "formatter",
+    "intellisense",
+    "language server",
     "lint",
+    "linter",
+    "lsp",
     "proto",
     "proto3",
     "protobuf",
-    "protocol buffers"
+    "protocol buffers",
+    "protovalidate"
   ],
   "activationEvents": [
     "workspaceContains:**/*.proto",


### PR DESCRIPTION
## Why

The display name was just "Buf" and the description was generic ("Visual
Studio Code support for Buf"), so the listing undersold what the extension
does and was hard to find by the terms people actually use - Protobuf,
.proto, and Protovalidate.

## What

- Display name, description, and keywords now cover Protobuf, .proto, and
  Protovalidate/CEL - all capabilities the Buf language server provides today
  (Protovalidate/CEL hovers, completions, and go-to-definition shipped in buf
  v1.67.0+).
- Rewrote the README intro to lead with the language-server capabilities, and
  added a Protovalidate/CEL feature entry.
- Added Marketplace and Open VSX install links up top; sorted the reference
  links.

Metadata and docs only - no behavior change.